### PR TITLE
nuevo endpoint de API Compra para obtener compras segun su estado

### DIFF
--- a/src/main/java/org/tallerjava/moduloCompra/interfase/remota/CompraAPI.java
+++ b/src/main/java/org/tallerjava/moduloCompra/interfase/remota/CompraAPI.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.tallerjava.moduloCompra.aplicacion.ServicioCompra;
+import org.tallerjava.moduloCompra.dominio.EstadoCompra;
 import org.tallerjava.moduloCompra.dominio.Tarjeta;
 import org.tallerjava.moduloCompra.dominio.datatypes.DTOPago;
 import org.tallerjava.moduloCompra.dominio.datatypes.DTOResumenVentas;
@@ -115,4 +116,24 @@ public class CompraAPI {
             }
     }
 
+    //curl -v "http://localhost:8080/TallerJakartaEEPasarelaPagos/api/compra/1/resumen/por-estado?estado=APROBADA"
+    //curl -v "http://localhost:8080/TallerJakartaEEPasarelaPagos/api/compra/1/resumen/por-estado?estado=RECHAZADA"
+    @GET
+    @Path("/{idComercio}/resumen/por-estado")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response obtenerResumenDeVentasDiario(
+        @PathParam("idComercio") Integer idComercio,
+        @QueryParam("estado") EstadoCompra estado) {
+
+        DTOResumenVentas resumen = servicioCompra.resumenVentasPorEstado(idComercio, estado);
+        if (resumen == null) {
+            return Response
+            .serverError()
+            .entity("{\"error\": \"Error al generar el resumen\"}")
+            .status(500)
+            .build();
+        } else {
+            return Response.ok(resumen).build();
+        }
+    }
 }

--- a/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml
+++ b/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml
@@ -3,9 +3,9 @@
 	<persistence-unit name="tallerJakartaEE">
 		 <jta-data-source>java:jboss/MariaDB</jta-data-source>
             <properties>
-                <!-- <property
+                <property
                     name="jakarta.persistence.schema-generation.database.action"
-                    value="drop-and-create" /> -->
+                    value="drop-and-create" />
                 <property name="jakarta.persistence.sql-load-script-source"
                     value="META-INF/initial_data.sql" />
                 <property name="eclipselink.logging.level.sql" value="FINE" />


### PR DESCRIPTION
Agregue una nueva operacion a la API del modulo Compra que permite obtener el resumen de ventas de un comercio filtrando las ventas por estado.