### PR TITLE
evitando ejecucion de tests de integracion previo al deploy

### DIFF
--- a/curlsAPIcomercio.txt
+++ b/curlsAPIcomercio.txt
@@ -65,6 +65,8 @@
 
 ### 204 No Content
 >	curl -v --user nextriguser:1234 http://localhost:8080/TallerJakartaEEPasarelaPagos/api/comercio/1/pos/1/estado -H "Content-Type: application/json" -d '{"estado": "false"}'
+// permito que un admin modifique el estado aparte del comercio que es dueño
+>	curl -v --user apiadmin:1234 http://localhost:8080/TallerJakartaEEPasarelaPagos/api/comercio/1/pos/1/estado -H "Content-Type: application/json" -d '{"estado": "true"}'
 
 ### 403 Forbidden
 // envio credenciales invalidas

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,17 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${compiler-plugin.version}</version>
 			</plugin>
+
+            <plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.5.3</version>
+				<configuration>
+					<excludes>
+            			**/integration/*.java
+        			</excludes>
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>${war-plugin.version}</version>

--- a/src/test/java/org/tallerjava/moduloTransferencia/integration/ServicioTransferenciaImplTest.java
+++ b/src/test/java/org/tallerjava/moduloTransferencia/integration/ServicioTransferenciaImplTest.java
@@ -1,4 +1,4 @@
-package org.tallerjava.moduloTransferencia;
+package org.tallerjava.moduloTransferencia.integration;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
## Problema
Los tests de integración que hacen consultas http al servidor se ejecutan, por defecto, al mismo tiempo que los demás tests unitarios. [Esto es luego de la fase `compile` y previo a la fase `package`, y por lo tanto antes del `deploy` del servidor](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). Esto hace que los tests fallen al ejecutar el comando `mvn package` ya que no pueden comunicarse con el servidor.
Más específicamente, el test `ServicioTransferenciaImplTest` falla por este motivo al ejecutar `mvn package`.

## Solución
Excluir los tests de integración que requieran que el servidor esté en funcionamiento de la fase `test` de maven. Para eso incluimos en el `pom.xml` un [plugin de maven](https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html) que nos permite excluir o incluir ciertos tests de dicha fase.

## Cambios
1. Se agrega el plugin `maven-surefire-plugin` al `pom.xml`. Se excluyen los tests encontrados bajo el directorio **/integration.
2. Se mueve el archivo `ServicioTransferenciaImplTest.java` a una carpeta `integration` dentro de la carpeta en la que se encontraba.