### PR TITLE
Feat: se modifica ratelimiter

### DIFF
--- a/src/main/java/org/tallerjava/servicioExterno/rateLimiter/RateLimitFilter.java
+++ b/src/main/java/org/tallerjava/servicioExterno/rateLimiter/RateLimitFilter.java
@@ -8,41 +8,64 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
+import java.util.HashMap;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 
 @Provider
 public class RateLimitFilter implements ContainerRequestFilter {
 
-    private static final int REQUESTS_PER_MINUTE = 10;
+    // Definir limite por endpoint - x/minuto
+    private static final Map<String, Integer> LIMITS = new HashMap<>();
+    static {
+        LIMITS.put("nueva-compra", 50); // 50/minuto
+    }
+    
     private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
-
+    
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        String ip = requestContext.getHeaderString("X-Forwarded-For");
-        if (ip == null) {
-            ip = requestContext.getUriInfo().getRequestUri().getHost();
-        }
-
-        Bucket bucket = buckets.computeIfAbsent(ip, k -> createNewBucket());
+        String path = requestContext.getUriInfo().getPath();
+        
+        String key = path;
+        System.out.println("Path recibido: '" + path + "'");
+        int limit = getLimitForPath(path);
+        System.out.println("Limite aplicado: " + limit);
+        Bucket bucket = buckets.computeIfAbsent(key, k -> createNewBucket(limit));
+        
         if (bucket.tryConsume(1)) {
             requestContext.setProperty("rate-limit-restante", bucket.getAvailableTokens());
-            requestContext.setProperty("rate-limit-total", REQUESTS_PER_MINUTE);
+            requestContext.setProperty("rate-limit-total", limit);
             requestContext.setProperty("rate-limit-reinicio", 60);
             return;
         } else {
             requestContext.abortWith(Response.status(429)
-                .entity("Rate limit exceedido. Intenta de nuevo mas tarde.")
+                .entity("Rate limit excedido. Intenta de nuevo mas tarde.")
                 .build());
         }
     }
-
-    private Bucket createNewBucket() {
-        Bandwidth limit = Bandwidth.builder()
-            .capacity(REQUESTS_PER_MINUTE)
-            .refillGreedy(REQUESTS_PER_MINUTE, Duration.ofMinutes(1))
+    
+    private int getLimitForPath(String path) {
+        // SE verificar si es un endpoint de nueva-compra (cualquier comercio)
+        if (path.matches("/compra/\\d+/nueva-compra")) {
+            return LIMITS.get("nueva-compra");
+        }
+        
+        if (LIMITS.containsKey(path)) {
+            return LIMITS.get(path);
+        }
+        
+        return 100;
+    }
+    
+    private Bucket createNewBucket(int limit) {
+        Bandwidth bandwidth = Bandwidth.builder()
+            .capacity(limit)
+            .refillIntervally(limit, Duration.ofMinutes(1))
             .build();
-
-        return Bucket.builder().addLimit(limit).build();
+        
+        return Bucket.builder()
+            .addLimit(bandwidth)
+            .build();
     }
 }


### PR DESCRIPTION
## Modificacion de rate limiter

### Cambios:

* Ahora el ratelimiter es por endpoint no por ip.
* Se limita el endopint en el cual se procesa el pago que era lo que se pedia "nueva-compra"
* Se limita por id de comercio es decir, limite de 20, al comercio 1 le pueden hacer 15 req, y al comercio 2 le pueden hacer 17, el 1 tendra 5 restantes y el 2 tendra 3 req restantes
* Por defecto limita a 100 req para todos los demas endpoints que no se les defina un limite en particular.

